### PR TITLE
Update WhiteCore benchmark speed

### DIFF
--- a/OpenBench/config.py
+++ b/OpenBench/config.py
@@ -87,7 +87,7 @@ OPENBENCH_CONFIG = {
         },
 
         'WhiteCore' : {
-            'nps': 3500000,
+            'nps': 2200000,
             'base': 'master',
             'book': 'UHO_XXL_+0.90_+1.19.epd',
             'bounds': '[0.00, 5.00]',


### PR DESCRIPTION
Updates the benchmark speed to be more accurate, addressing the issue of OpenBench running longer time controls than necessary.