### PR TITLE
Update WhiteCore benchmark speed again

### DIFF
--- a/OpenBench/config.py
+++ b/OpenBench/config.py
@@ -87,7 +87,7 @@ OPENBENCH_CONFIG = {
         },
 
         'WhiteCore' : {
-            'nps': 2200000,
+            'nps': 1300000,
             'base': 'master',
             'book': 'UHO_XXL_+0.90_+1.19.epd',
             'bounds': '[0.00, 5.00]',


### PR DESCRIPTION
Recent changes slowed down WhiteCore even more, resulting a 1.3Mnps benchmark speed.